### PR TITLE
Fix set_fact task overwriting configuration

### DIFF
--- a/tasks/generate_interfaces.yml
+++ b/tasks/generate_interfaces.yml
@@ -13,8 +13,10 @@
 - name: Prepare interface configuration if not defined
   set_fact:
     ifupdown_interfaces: '{{ ifupdown_default_interfaces }}'
-  when: (ifupdown_dependent_interfaces is undefined and
-         (ifupdown_default_interfaces is defined and ifupdown_default_interfaces))
+  when: ((ifupdown_interfaces is undefined or
+         (ifupdown_interfaces is defined and not ifupdown_interfaces)) and
+         (ifupdown_dependent_interfaces is undefined and
+         (ifupdown_default_interfaces is defined and ifupdown_default_interfaces)))
 
 - name: Prepare interface configuration via dependency if defined
   set_fact:


### PR DESCRIPTION
set_fact task which was setting 'ifupdown_interfaces' variable was
incorrectly redefining it when a configuration in the inventory was
present.
