### PR TITLE
Allow type 'interface' to generate from template

### DIFF
--- a/templates/etc/network/interfaces.d/interface.j2
+++ b/templates/etc/network/interfaces.d/interface.j2
@@ -1,6 +1,6 @@
 # This file is managed by Ansible, all changes will be lost
 
-{% if (item.type is undefined and item.iface in ansible_interfaces) or (item.force is defined and item.force) %}
+{% if ((item.type is undefined or (item.type is defined and item.type == 'interface')) and item.iface in ansible_interfaces) or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} interface
 {% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
 auto {{ item.iface }}
@@ -23,7 +23,7 @@ iface {{ item.iface }} inet static
 
 {% endfor %}
 {% endif %}
-{% elif item.type is undefined and item.iface not in ansible_interfaces %}
+{% elif ((item.type is undefined or (item.type is defined and item.type == 'interface')) and item.iface not in ansible_interfaces) %}
 # Interface {{ item.iface }} not found
 {% endif %}
 


### PR DESCRIPTION
Default 'interface' template was meant to be used if "type" key was not
specified, but it didn't account for type to be set as 'interface'.

Fixes #2
