### PR TITLE
Add support for autoconfigured 6to4 tunnels

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,12 @@ ifupdown_ignore_networkmanager: False
 # in practice. Specify a filename without '.yml' extension
 ifupdown_default_config: ""
 
+# Manage automatic 6to4 tunnel - set to IPv4 public address to enable, set
+# to False to disable. This tunnel is configured on hardware hosts only (not on
+# virtual machines or containers). It won't be managed if you have native IPv6
+# connectivity.
+ifupdown_6to4: '{{ ansible_default_ipv4.address }}'
+
 # List of network interfaces. If it's not defined, ifupdown role will
 # automatically select a default set based on variables like presence of
 # NetworkManager or value of ansible_virtualization_type

--- a/templates/etc/network/interfaces.d/6to4.j2
+++ b/templates/etc/network/interfaces.d/6to4.j2
@@ -1,0 +1,31 @@
+# This file is managed by Ansible, all changes will be lost
+
+{% if ((item.type is defined and item.type == '6to4') and (ifupdown_6to4 is defined and ifupdown_6to4)) %}
+{% if ((item.force is defined and item.force) or (item.local is defined and item.local) or
+       ((ansible_default_ipv6.interface is undefined or (ansible_default_ipv6.interface is defined and ansible_default_ipv6.interface == '6to4')) and
+        ansible_default_ipv4.address | ipv4('public'))) %}
+# Configuration for IPv6 in IPv4 tunnel
+{% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
+auto 6to4
+{% elif (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is defined and item.inet != 'manual' %}
+auto 6to4
+{% elif (item.auto is defined and item.auto == True) %}
+auto 6to4
+{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+allow-{{ item.allow }} 6to4
+{% endif %}
+iface 6to4 inet6 6to4
+{% if item.local is defined and item.local %}
+        local {{ item.local }}
+{% elif ifupdown_6to4 is defined and ifupdown_6to4 | ipv4 and ifupdown_6to4 | ipv4('public') %}
+        local {{ ifupdown_6to4 }}
+{% else %}
+        local {{ ansible_default_ipv4.address }}
+{% endif %}
+{% else %}
+# 6to4 autoconfiguration is disabled
+{% endif %}
+{% else %}
+# Configuration of IPv6 in IPv4 tunnel is disabled
+{% endif %}
+

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -23,4 +23,8 @@ ifupdown_default_interfaces:
     type: 'bridge'
     port: '{{ ifupdown_internal_interface }}'
 
+    # Autoconfigured 6to4 tunnel
+  - iface: '6to4'
+    type:  '6to4'
+    filename: 'tunnel_6to4'
 

--- a/vars/networkmanager_installed.yml
+++ b/vars/networkmanager_installed.yml
@@ -2,6 +2,11 @@
 
 # Don't configure any default interfaces if NetworkManager is present
 
-ifupdown_default_interfaces: []
+ifupdown_default_interfaces:
+
+    # Autoconfigured 6to4 tunnel
+  - iface: '6to4'
+    type:  '6to4'
+    filename: 'tunnel_6to4'
 
 


### PR DESCRIPTION
6to4 (https://en.wikipedia.org/wiki/6to4) is a method to tunnel IPv6
traffic in IPv4 packets. 'debops.ifupdown' role will check if default or
specified IPv4 address of a host is a public one - if it is and IPv6
network connectivity is not present, an 6to4 tunnel will be
automatically configured. These tunnels are configured only on public
IPv4 network, hosts behind NAT will not have 6to4 enabled and should
instead be configured via normal IPv6 router advertisements.
