### PR TITLE
Rewrite 6to4 tunnel support in debops.ifupdown

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,12 +25,6 @@ ifupdown_ignore_networkmanager: False
 # in practice. Specify a filename without '.yml' extension
 ifupdown_default_config: ""
 
-# Manage automatic 6to4 tunnel - set to IPv4 public address to enable, set
-# to False to disable. This tunnel is configured on hardware hosts only (not on
-# virtual machines or containers). It won't be managed if you have native IPv6
-# connectivity.
-ifupdown_6to4: '{{ ansible_default_ipv4.address }}'
-
 # List of network interfaces. If it's not defined, ifupdown role will
 # automatically select a default set based on variables like presence of
 # NetworkManager or value of ansible_virtualization_type

--- a/templates/etc/network/interfaces.d/6to4.j2
+++ b/templates/etc/network/interfaces.d/6to4.j2
@@ -1,27 +1,35 @@
+{#
+#    ==== debops.ifupdown template for 6to4 network interface ====
+#
+#    Parameters:
+#
+#    - tunnel_6to4_ipv4_interface: ''
+#        name of IPv4 interface to connect through, it needs a public IPv4
+#        address present
+#
+#    - tunnel_6to4_iface: ''
+#        name of created tunnel interface
+#
+#}
+{% set ifupdown_tpl_6to4_ipv4_interface = item.tunnel_6to4_ipv4_interface | default(ansible_default_ipv4.interface) %}
+{% set ifupdown_tpl_6to4_iface = item.tunnel_6to4_iface | default('6to4') %}
+{% set ifupdown_tpl_6to4_ipv4_address = hostvars[inventory_hostname]["ansible_" + ifupdown_tpl_6to4_ipv4_interface].ipv4.address | default('') %}
 # This file is managed by Ansible, all changes will be lost
 
-{% if ((item.type is defined and item.type == '6to4') and (ifupdown_6to4 is defined and ifupdown_6to4)) %}
-{% if ((item.force is defined and item.force) or (item.local is defined and item.local) or
-       ((ansible_default_ipv6.interface is undefined or (ansible_default_ipv6.interface is defined and ansible_default_ipv6.interface == '6to4')) and
-        ansible_default_ipv4.address | ipv4('public'))) %}
+{% if (item.type is defined and item.type == '6to4') %}
+{% if ((item.force is defined and item.force) or (ifupdown_tpl_6to4_ipv4_address | ipv4('6to4'))) %}
 # Configuration for IPv6 in IPv4 tunnel
 {% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
-auto 6to4
+auto {{ ifupdown_tpl_6to4_iface }}
 {% elif (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is defined and item.inet != 'manual' %}
-auto 6to4
+auto {{ ifupdown_tpl_6to4_iface }}
 {% elif (item.auto is defined and item.auto == True) %}
-auto 6to4
+auto {{ ifupdown_tpl_6to4_iface }}
 {% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
-allow-{{ item.allow }} 6to4
+allow-{{ item.allow }} {{ ifupdown_tpl_6to4_iface }}
 {% endif %}
-iface 6to4 inet6 6to4
-{% if item.local is defined and item.local %}
-        local {{ item.local }}
-{% elif ifupdown_6to4 is defined and ifupdown_6to4 | ipv4 and ifupdown_6to4 | ipv4('public') %}
-        local {{ ifupdown_6to4 }}
-{% else %}
-        local {{ ansible_default_ipv4.address }}
-{% endif %}
+iface {{ ifupdown_tpl_6to4_iface }} inet6 6to4
+        local {{ ifupdown_tpl_6to4_ipv4_address }}
 {% else %}
 # 6to4 autoconfiguration is disabled
 {% endif %}

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -23,8 +23,3 @@ ifupdown_default_interfaces:
     type: 'bridge'
     port: '{{ ifupdown_internal_interface }}'
 
-    # Autoconfigured 6to4 tunnel
-  - iface: '6to4'
-    type:  '6to4'
-    filename: 'tunnel_6to4'
-

--- a/vars/networkmanager_installed.yml
+++ b/vars/networkmanager_installed.yml
@@ -2,11 +2,5 @@
 
 # Don't configure any default interfaces if NetworkManager is present
 
-ifupdown_default_interfaces:
-
-    # Autoconfigured 6to4 tunnel
-  - iface: '6to4'
-    type:  '6to4'
-    filename: 'tunnel_6to4'
-
+ifupdown_default_interfaces: []
 


### PR DESCRIPTION
Ipv6 6to4 tunnel is now configured via other roles using dependency
variables. It's also not enabled by default in normal interface
configuration.
