### PR TITLE
Support basic static configuration

### DIFF
--- a/tasks/check_static.yml
+++ b/tasks/check_static.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Check if default configuration is static
+  shell: grep 'static' /etc/network/interfaces.dpkg-divert || true
+  register: ifupdown_register_static_config
+  changed_when: False
+
+- name: Enable static default configuration if detected
+  set_fact:
+    ifupdown_static_config: 'static'
+  when: ((ifupdown_register_static_config is defined and ifupdown_register_static_config) and
+         ifupdown_register_static_config.stdout)
+

--- a/tasks/generate_interfaces.yml
+++ b/tasks/generate_interfaces.yml
@@ -6,6 +6,7 @@
     - '../vars/{{ ifupdown_default_config }}.yml'
     - '../vars/networkmanager_{{ ifupdown_networkmanager }}.yml'
     - '../vars/virtualization_{{ ansible_virtualization_type }}_{{ ansible_virtualization_role }}.yml'
+    - '../vars/default_{{ ifupdown_static_config }}.yml'
     - '../vars/default.yml'
   when: (ifupdown_interface is undefined or
          (ifupdown_interfaces is defined and not ifupdown_interfaces))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
 - include: check_networkmanager.yml
   when: ifupdown is defined and ifupdown
 
+- include: check_static.yml
+  when: ifupdown is defined and ifupdown
+
 - include: generate_interfaces.yml
   when: ifupdown is defined and ifupdown
 

--- a/vars/default_static.yml
+++ b/vars/default_static.yml
@@ -1,0 +1,18 @@
+---
+
+# This is a fallback default static interface configuration
+# 'debops.ifupdown' role checks if original /etc/network/interfaces had
+# a static configuration and if true, enables this fallback with default IPv4
+# interface
+
+ifupdown_default_interfaces:
+
+  - iface: '{{ ansible_default_ipv4.interface }}'
+    inet: 'static'
+    options: |
+      address {{ ansible_default_ipv4.address }}
+      network {{ ansible_default_ipv4.network }}
+      netmask {{ ansible_default_ipv4.netmask }}
+      gateway {{ ansible_default_ipv4.gateway }}
+      dns-nameserver {{ ansible_default_ipv4.gateway }}
+


### PR DESCRIPTION
In case a DHCP server is not available, role will check if original
configuration has been configured with static interfaces. If true, basic
static configuration will be enabled instead of DHCP.
