### PR TITLE
Fix for supporting 'ansible-playbook --check' mode

### DIFF
--- a/tasks/check_static.yml
+++ b/tasks/check_static.yml
@@ -10,3 +10,5 @@
   set_fact:
     ifupdown_static_config:
        "{{ ifupdown_register_static_config.rc == 0 and 'static' }}"
+  when: ifupdown_register_static_config.rc is defined and
+        ifupdown_register_static_config.rc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,21 @@
 ---
+
+  # If static configuration is detected, don't manage interfaces automatically
 - include: check_static.yml
   when: ifupdown
 
 - include: divert_interfaces.yml
-  when: ifupdown and ifupdown_static_config != 'static'
+  when: (ifupdown and (ifupdown_static_config is undefined or
+         (ifupdown_static_config is defined and ifupdown_static_config != 'static')))
 
 - include: check_networkmanager.yml
   when: ifupdown and not ifupdown_ignore_networkmanager
 
 - include: generate_interfaces.yml
-  when: ifupdown and ifupdown_static_config != 'static'
+  when: (ifupdown and (ifupdown_static_config is undefined or
+         (ifupdown_static_config is defined and ifupdown_static_config != 'static')))
 
 - include: revert_interfaces.yml
-  when: not ifupdown and ifupdown_static_config != 'static'
+  when: (not ifupdown and (ifupdown_static_config is undefined or
+         (ifupdown_static_config is defined and ifupdown_static_config != 'static')))
 


### PR DESCRIPTION
This fix will ensure that the '--check' mode will run correctly without
creating errors about undefined variables.
