### PR TITLE
Fix role enable/disable logic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,10 @@
 - name: Recalculate ifupdown based on POSIX capabilities
   set_fact:
      ifupdown: |
-       '{{ ifupdown and
-           (ifupdown_ignore_cap12s
-           or (ansible_local|d() and ansible_local.cap12s|d() and
-               (not ansible_local.cap12s.enabled
-                or 'cap_net_admin' in ansible_local.cap12s.list))) }}'
+       {{ (ifupdown | bool and (ifupdown_ignore_cap12s | bool or
+           (ansible_local|d() and ansible_local.cap12s|d() and
+            (not ansible_local.cap12s.enabled | bool or
+             (ansible_local.cap12s.enabled | bool and "cap_net_admin" in ansible_local.cap12s.list))))) }}
 
   # If static configuration is detected, don't manage interfaces automatically
 - include: check_static.yml


### PR DESCRIPTION
Now role should correctly handle configuration of interfaces on systems
which have POSIX capabilities disabled (ie. full root access).