### PR TITLE
Change interface configuration logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+v0.1.1
+------
+
+*Unreleased*
+
+- Add ``item.port_present`` parameter in bridge configuration. It can be used
+  to enable or disable specific bridge interface depending on presence of
+  a given network interface in ``ansible_interfaces`` list, but does not affect
+  the configuration of the bridge itself. [drybjed]
+
 v0.1.0
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,27 @@ v0.1.1
 - Add IPv6 SLAAC configuration on all default interfaces; this is required on
   Debian Jessie to enable IPv6 address autoconfiguration.  [drybjed]
 
+- Rewrite network interface configuration logic.
+
+  Generate interface configuration in a separate
+  ``/etc/network/interfaces.config.d/`` directory instead of directly in
+  ``/etc/network/interfaces.d/`` directory. Provide original configuration at
+  first run of the role, which is required to properly shut down all network
+  interfaces, when state of the networking configuration is undefined.
+
+  Instead of disabling and enabling network interfaces directly using Ansible
+  tasks and ``ifup`` / ``ifdown`` commands, delegate the reconfiguration
+  process to an external script installed on the host. The script will properly
+  disable and enable interfaces in systems using sysvinit, upstart and systemd.
+
+  The ifupdown configuration script will shut down all network interfaces on
+  the first run of the ``debops.ifupdown`` role, apply configuration changes
+  from the ``/etc/network/interfaces.config.d/`` directory to
+  ``/etc/network/interfaces.d/`` directory and then start only enabled
+  interfaces using ``ifup`` command or ``ifup@.service`` systemd service. Only
+  network interfaces which have been modified will be enabled/disabled on
+  subsequent runs. [drybjed]
+
 v0.1.0
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ v0.1.1
   to control specific interfaces by the hotplug events using ``ifup`` and
   ``ifdown`` commands or ``ifup@.service`` under ``systemd``. [drybjed]
 
+- Add IPv6 SLAAC configuration on all default interfaces; this is required on
+  Debian Jessie to enable IPv6 address autoconfiguration.  [drybjed]
+
 v0.1.0
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,15 @@ v0.1.1
   a given network interface in ``ansible_interfaces`` list, but does not affect
   the configuration of the bridge itself. [drybjed]
 
+- Clean up ``allow-auto`` and ``allow-hotplug`` options in interface
+  configuration. By default both of these parameters will be added
+  automatically by ``debops.ifupdown`` to most of the interface types unless
+  specifically disabled.
+
+  This tells the system to start the interfaces at boot time, as well as allows
+  to control specific interfaces by the hotplug events using ``ifup`` and
+  ``ifdown`` commands or ``ifup@.service`` under ``systemd``. [drybjed]
+
 v0.1.0
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,11 @@ ifupdown_internal_interface: 'eth1'
 # been modified? Set to False to enable "dry-mode"
 ifupdown_reconfigure: True
 
-# Delay in seconds between stopping an interface and starting it again
-ifupdown_reconfigure_delay: '2'
+# Name of the file that contains an initial state of the ifupdown configuration
+# and indicates that all network interfaces should be stopped before
+# configuration
+ifupdown_reconfigure_init_file: '/etc/network/interfaces.d/old-interfaces'
+
 
 # Should ifupdown role ignore presence of NetworkManager and generate the
 # configuration in /etc/network/interfaces.d/?

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ ifupdown_interfaces: []
   #  port: ''				# bridge port to check for existence in
   #                                     # ansible_interfaces, adds 'bridge_ports <port>' line
   #					# (one ping, err, port only)
+  #  port_present: ''                   # enable a bridge if given port is present in ansible_interfaces
   #  device: ''				# VLAN device to use, adds 'vlan_raw_device <device>' line
   #
   #  # Management of files in /etc/network/interfaces.d/

--- a/tasks/divert_interfaces.yml
+++ b/tasks/divert_interfaces.yml
@@ -3,6 +3,30 @@
 - name: Divert original /etc/network/interfaces
   command: dpkg-divert --quiet --local --divert /etc/network/interfaces.dpkg-divert --rename /etc/network/interfaces
            creates=/etc/network/interfaces.dpkg-divert
+  register: ifupdown_register_divert
+
+- name: Create /etc/network/interfaces.d directory
+  file:
+    path: '/etc/network/interfaces.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Provide original interfaces temporarily
+  command: cp /etc/network/interfaces.dpkg-divert {{ ifupdown_reconfigure_init_file }}
+  when: ifupdown_register_divert is defined and ifupdown_register_divert.changed
+
+- name: Remove redundant configuration from original interfaces
+  lineinfile:
+    dest: '{{ ifupdown_reconfigure_init_file }}'
+    regexp: '{{ item }}'
+    state: 'absent'
+  with_items:
+    - '^source /etc/network/interfaces.d/*'
+    - '^auto lo'
+    - '^iface lo inet loopback'
+  when: ifupdown_register_divert is defined and ifupdown_register_divert.changed
 
 - name: Create /etc/network/interfaces
   template:

--- a/tasks/generate_interfaces.yml
+++ b/tasks/generate_interfaces.yml
@@ -37,31 +37,64 @@
     group: 'root'
     mode: '0755'
 
+- name: Create /etc/network/interfaces.config.d directory
+  file:
+    path: '/etc/network/interfaces.config.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Install network reconfiguration script
+  template:
+    src: 'usr/local/lib/ifupdown-reconfigure-interfaces.j2'
+    dest: '{{ ansible_local.root.lib + "/ifupdown-reconfigure-interfaces" }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
 - name: Delete interface configuration if requested
   file:
-    path: '/etc/network/interfaces.d/{{ item.weight | default("00") }}_{{ item.filename | default(item.type | default("interface") + "_" + item.iface) }}{% if item.inet is defined and item.inet %}_ipv4{% endif %}{% if item.inet6 is defined and item.inet6 %}_ipv6{% endif %}'
+    path: '{{ "/etc/network/interfaces.config.d/" + item.weight | default("00") + "_" + item.filename | default(item.type | default("interface") + "_" + item.iface) + ("_ipv4" if (item.inet is defined and item.inet) else "") + ("_ipv6" if (item.inet6 is defined and item.inet6) else "") }}'
     state: 'absent'
   with_items: ifupdown_interfaces
+  register: ifupdown_register_interfaces_removator
   when: ((item.iface is defined and item.iface) and
          (item.delete is defined and item.delete))
 
 - name: Generate interface configuration
   template:
     src: 'etc/network/interfaces.d/{{ item.type | default("interface") }}.j2'
-    dest: '/etc/network/interfaces.d/{{ item.weight | default("00") }}_{{ item.filename | default(item.type | default("interface") + "_" + item.iface) }}{% if item.inet is defined and item.inet %}_ipv4{% endif %}{% if item.inet6 is defined and item.inet6 %}_ipv6{% endif %}'
+    dest: '{{ "/etc/network/interfaces.config.d/" + item.weight | default("00") + "_" + item.filename | default(item.type | default("interface") + "_" + item.iface) + ("_ipv4" if (item.inet is defined and item.inet) else "") + ("_ipv6" if (item.inet6 is defined and item.inet6) else "") }}'
     owner: 'root'
     group: 'root'
     mode: '0644'
   with_items: ifupdown_interfaces
-  register: ifupdown_register_status
+  register: ifupdown_register_interfaces_generator
   when: ((item.iface is defined and item.iface) and
          (item.delete is undefined or not item.delete))
 
-- name: Reconfigure interfaces
-  shell: ifdown {{ item.item.iface }} ; sleep {{ ifupdown_reconfigure_delay }} ; ifup {{ item.item.iface }}
-  with_items: ifupdown_register_status.results
-  when: ((ifupdown_register_status.results is defined and ifupdown_register_status.results) and
-         (ifupdown_reconfigure is defined and ifupdown_reconfigure == True) and
-         (item.changed == True) and
-         (item.item.inet is undefined or item.item.inet != 'manual'))
+- name: Create random temporary directory for ifupdown data
+  command: mktemp -d
+  register: ifupdown_register_tempdir
+  when: (((ifupdown_register_interfaces_removator is defined and ifupdown_register_interfaces_removator.changed) or
+          (ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed)) and
+         (ifupdown_reconfigure is defined and ifupdown_reconfigure))
+
+- name: Generate list of changed interfaces in temporary file
+  template:
+    src: 'tmp/ifupdown-changed-interfaces.j2'
+    dest: '{{ ifupdown_register_tempdir.stdout + "/ifupdown-changed-interfaces" }}'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when: (((ifupdown_register_interfaces_removator is defined and ifupdown_register_interfaces_removator.changed) or
+          (ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed)) and
+         (ifupdown_reconfigure is defined and ifupdown_reconfigure))
+
+- name: Reconfigure network interfaces
+  command: '{{ ansible_local.root.lib + "/ifupdown-reconfigure-interfaces " + ifupdown_register_tempdir.stdout + "/ifupdown-changed-interfaces" }}'
+  when: (((ifupdown_register_interfaces_removator is defined and ifupdown_register_interfaces_removator.changed) or
+          (ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed)) and
+         (ifupdown_reconfigure is defined and ifupdown_reconfigure))
 

--- a/templates/etc/network/interfaces.d/6to4.j2
+++ b/templates/etc/network/interfaces.d/6to4.j2
@@ -19,13 +19,12 @@
 {% if (item.type is defined and item.type == '6to4') %}
 {% if ((item.force is defined and item.force) or (ifupdown_tpl_6to4_ipv4_address | ipv4('6to4'))) %}
 # Configuration for IPv6 in IPv4 tunnel
-{% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
-auto {{ ifupdown_tpl_6to4_iface }}
-{% elif (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is defined and item.inet != 'manual' %}
-auto {{ ifupdown_tpl_6to4_iface }}
-{% elif (item.auto is defined and item.auto == True) %}
-auto {{ ifupdown_tpl_6to4_iface }}
-{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+{% if item.auto is undefined or item.auto %}
+allow-auto {{ item.iface }}
+{% endif %}
+{% if (item.allow is undefined and (item.inet is undefined or (item.inet is defined and item.inet != 'manual'))) %}
+allow-hotplug {{ ifupdown_tpl_6to4_iface }}
+{% elif (item.allow is defined and item.allow) %}
 allow-{{ item.allow }} {{ ifupdown_tpl_6to4_iface }}
 {% endif %}
 iface {{ ifupdown_tpl_6to4_iface }} inet6 6to4

--- a/templates/etc/network/interfaces.d/bond.j2
+++ b/templates/etc/network/interfaces.d/bond.j2
@@ -2,9 +2,12 @@
 
 {% if (item.type is defined and item.type == 'bond') or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} bonding interface
-{% if (item.auto is undefined or item.auto) and item.allow is undefined %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+{% if item.auto is undefined or item.auto %}
+allow-auto {{ item.iface }}
+{% endif %}
+{% if item.allow is undefined %}
+allow-hotplug {{ item.iface }}
+{% elif (item.allow is defined and item.allow) %}
 allow-{{ item.allow }} {{ item.iface }}
 {% endif %}
 iface {{ item.iface }} {% if item.inet is defined and item.inet %}inet {{ item.inet }}{% elif item.inet6 is defined and item.inet6 %}inet6 {{ item.inet6 }}{% else %}inet dhcp{% endif %}

--- a/templates/etc/network/interfaces.d/bridge.j2
+++ b/templates/etc/network/interfaces.d/bridge.j2
@@ -1,6 +1,7 @@
 # This file is managed by Ansible, all changes will be lost
 
 {% if item.type is defined and item.type == 'bridge' %}
+{% if (item.port_present is undefined or item.port_present in ansible_interfaces or (item.force is defined and item.force)) %}
 {% if (item.port is undefined) or (item.port is defined and item.port in ansible_interfaces) or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} bridge
 {% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
@@ -37,6 +38,9 @@ iface {{ item.iface }} inet static
 {% endif %}
 {% else %}
 # Cannot find port {{ item.port }} for bridge {{ item.iface }}
+{% endif %}
+{% else %}
+# Interface {{ item.port_present }} not found
 {% endif %}
 {% else %}
 # Wrong configuration for {{ item.iface }} bridge

--- a/templates/etc/network/interfaces.d/bridge.j2
+++ b/templates/etc/network/interfaces.d/bridge.j2
@@ -4,13 +4,12 @@
 {% if (item.port_present is undefined or item.port_present in ansible_interfaces or (item.force is defined and item.force)) %}
 {% if (item.port is undefined) or (item.port is defined and item.port in ansible_interfaces) or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} bridge
-{% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is defined and item.inet != 'manual' %}
-auto {{ item.iface }}
-{% elif (item.auto is defined and item.auto == True) %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+{% if item.auto is undefined or item.auto %}
+allow-auto {{ item.iface }}
+{% endif %}
+{% if (item.allow is undefined and (item.inet is undefined or (item.inet is defined and item.inet != 'manual'))) %}
+allow-hotplug {{ item.iface }}
+{% elif (item.allow is defined and item.allow) %}
 allow-{{ item.allow }} {{ item.iface }}
 {% endif %}
 iface {{ item.iface }} {% if item.inet is defined and item.inet %}inet {{ item.inet }}{% elif item.inet6 is defined and item.inet6 %}inet6 {{ item.inet6 }}{% else %}inet dhcp{% endif %}

--- a/templates/etc/network/interfaces.d/interface.j2
+++ b/templates/etc/network/interfaces.d/interface.j2
@@ -2,11 +2,12 @@
 
 {% if ((item.type is undefined or (item.type is defined and item.type == 'interface')) and item.iface in ansible_interfaces) or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} interface
-{% if (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is undefined %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or item.auto) and item.allow is undefined and item.inet is defined and item.inet != 'manual' %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+{% if ((item.auto is undefined or item.auto) and (item.inet is undefined or (item.inet is defined and item.inet != 'manual'))) %}
+allow-auto {{ item.iface }}
+{% endif %}
+{% if (item.allow is undefined and (item.inet is undefined or (item.inet is defined and item.inet != 'manual'))) %}
+allow-hotplug {{ item.iface }}
+{% elif (item.allow is defined and item.allow) %}
 allow-{{ item.allow }} {{ item.iface }}
 {% endif %}
 iface {{ item.iface }} {% if item.inet is defined and item.inet %}inet {{ item.inet }}{% elif item.inet6 is defined and item.inet6 %}inet6 {{ item.inet6 }}{% else %}inet dhcp{% endif %}

--- a/templates/etc/network/interfaces.d/mapping.j2
+++ b/templates/etc/network/interfaces.d/mapping.j2
@@ -2,9 +2,12 @@
 
 {% if (item.type is defined and item.type == 'mapping') or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} mapping
-{% if (item.auto is undefined or item.auto) and item.allow is undefined %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+{% if item.auto is undefined or item.auto %}
+allow-auto {{ item.iface }}
+{% endif %}
+{% if item.allow is undefined %}
+allow-hotplug {{ item.iface }}
+{% elif (item.allow is defined and item.allow) %}
 allow-{{ item.allow }} {{ item.iface }}
 {% endif %}
 mapping {{ item.iface }}

--- a/templates/etc/network/interfaces.d/vlan.j2
+++ b/templates/etc/network/interfaces.d/vlan.j2
@@ -2,9 +2,12 @@
 
 {% if (item.type is defined and item.type == 'vlan') or (item.force is defined and item.force) %}
 # Configuration for {{ item.iface }} vlan
-{% if (item.auto is undefined or item.auto) and item.allow is undefined %}
-auto {{ item.iface }}
-{% elif (item.auto is undefined or not item.auto) and (item.allow is defined and item.allow) %}
+{% if item.auto is undefined or item.auto %}
+allow-auto {{ item.iface }}
+{% endif %}
+{% if item.allow is undefined %}
+allow-hotplug {{ item.iface }}
+{% elif (item.allow is defined and item.allow) %}
 allow-{{ item.allow }} {{ item.iface }}
 {% endif %}
 iface {{ item.iface }} {% if item.inet is defined and item.inet %}inet {{ item.inet }}{% elif item.inet6 is defined and item.inet6 %}inet6 {{ item.inet6 }}{% else %}inet dhcp{% endif %}

--- a/templates/tmp/ifupdown-changed-interfaces.j2
+++ b/templates/tmp/ifupdown-changed-interfaces.j2
@@ -1,0 +1,27 @@
+{% set ifupdown_tpl_removed_interfaces = [] %}
+{% if ifupdown_register_interfaces_removator is defined and ifupdown_register_interfaces_removator.changed %}
+{% for result in ifupdown_register_interfaces_removator.results %}
+{% if result.changed %}
+{% set _ = ifupdown_tpl_removed_interfaces.append(result.item.iface) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% set ifupdown_tpl_generated_interfaces = [] %}
+{% set ifupdown_tpl_enabled_interfaces = [] %}
+{% if ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed %}
+{% for result in ifupdown_register_interfaces_generator.results %}
+{% if result.changed %}
+{% set _ = ifupdown_tpl_generated_interfaces.append(result.item.iface) %}
+{% endif %}
+{% if result.changed and result.item|d() and (result.item.inet is undefined or result.item.inet != 'manual') %}
+{% set _ = ifupdown_tpl_enabled_interfaces.append(result.item.iface) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% set ifupdown_tpl_interface_list = (ifupdown_tpl_removed_interfaces + ifupdown_tpl_generated_interfaces) | sort | unique %}
+{% if ifupdown_tpl_interface_list %}
+interface_removed=( {{ (ifupdown_tpl_removed_interfaces | difference(ifupdown_tpl_generated_interfaces)) | sort | unique | join(" ") }} )
+interface_generated=( {{ (ifupdown_tpl_generated_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
+interface_enabled=( {{ (ifupdown_tpl_enabled_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
+interface_list=( {{ ifupdown_tpl_interface_list | join(" ") }} )
+{% endif %}

--- a/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
+++ b/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+# Reconfigure changed network interfaces
+# Part of the debops.ifupdown Ansible role
+# See https://github.com/debops/ansible-ifupdown/ for more details
+
+# If this file is present, interfaces are configured for the first time
+interface_init_file="{{ ifupdown_reconfigure_init_file }}"
+
+# Get the name of the temporary file which holds the list of modified interfaces
+interface_file="${1}"
+
+if [ -z "${interface_file}" ] ; then
+  echo "Error: no file with list of interfaces specified" ; exit 1
+fi
+
+# Make sure to remove the temporary directory when script is finished
+trap "rm -rf $(dirname ${interface_file})" EXIT
+
+containsElement () {
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  return 1
+}
+
+# Re-initialization of interfaces, stop all/unknown ones
+stop_networking () {
+
+  if [ -d /run/systemd/system ] ; then
+    systemctl stop networking.service
+  else
+    service networking stop
+  fi
+
+}
+
+# Check what init we are using and bring interface down correctly
+interface_down () {
+
+  if [ -d /run/systemd/system ] ; then
+
+    systemctl stop ifup@${1}.service
+
+    if $(containsElement "${1}" "${interface_removed[@]}") ; then
+      test -e /etc/systemd/system/multi-user.target.wants/ifup@${1}.service && \
+        rm -f /etc/systemd/system/multi-user.target.wants/ifup@${1}.service
+    fi
+
+  else
+    ifdown ${1}
+  fi
+
+}
+
+# Check what init we are using and bring interface up correctly
+interface_up () {
+
+  if [ -d /run/systemd/system ] ; then
+
+    if $(containsElement "${1}" "${interface_enabled[@]}") ; then
+      test -e /etc/systemd/system/multi-user.target.wants/ifup@${1}.service || \
+        ln -s /lib/systemd/system/ifup@.service /etc/systemd/system/multi-user.target.wants/ifup@${1}.service
+    fi
+
+    systemctl start ifup@${1}.service
+
+  else
+    ifup ${1}
+  fi
+
+}
+
+# Check if any interfaces have changed, if so, first stop all of them using
+# current configuration, apply the new configuration and bring the modified
+# interfaces back up
+if [ -r ${interface_file} ] ; then
+  source ${interface_file}
+
+  if [ ${{ '{' }}#interface_list[@]} -ge 0 ]; then
+
+    # Stop all interfaces on the first run
+    if [ -e ${interface_init_file} ] ; then
+
+      stop_networking
+
+    else
+
+      for iface in ${interface_list[@]} ; do
+        interface_down ${iface}
+      done
+
+    fi
+
+    # Apply new interface configuration
+    rsync -a --delete /etc/network/interfaces.config.d/ /etc/network/interfaces.d
+
+    for iface in ${interface_list[@]} ; do
+      interface_up ${iface}
+    done
+
+  fi
+
+fi
+

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -19,7 +19,21 @@ ifupdown_default_interfaces:
     type: 'bridge'
     port: '{{ ifupdown_external_interface }}'
 
+  - iface: 'br0'
+    auto: False
+    allow: False
+    type: 'bridge'
+    inet6: 'auto'
+    port_present: '{{ ifupdown_external_interface }}'
+
   - iface: 'br1'
     type: 'bridge'
     port: '{{ ifupdown_internal_interface }}'
+
+  - iface: 'br1'
+    auto: False
+    allow: False
+    type: 'bridge'
+    inet6: 'auto'
+    port_present: '{{ ifupdown_internal_interface }}'
 

--- a/vars/virtualization_lxc_guest.yml
+++ b/vars/virtualization_lxc_guest.yml
@@ -6,6 +6,15 @@ ifupdown_default_interfaces:
 
   - iface: '{{ ifupdown_external_interface }}'
 
+  - iface: '{{ ifupdown_external_interface }}'
+    auto: False
+    allow: False
+    inet6: 'auto'
+
   - iface: '{{ ifupdown_internal_interface }}'
 
+  - iface: '{{ ifupdown_internal_interface }}'
+    auto: False
+    allow: False
+    inet6: 'auto'
 


### PR DESCRIPTION
These changes will result in modified network interface configuration, networking will be stopped and might not come back up if interface configuration is not prepared correctly. Make sure that your current configuration exists in the new config directory by running command:

    ansible all -m command -a 'cp -r /etc/network/interfaces.d /etc/network/interfaces.config.d'

This should make sure that all network interface configuration is preserved on the next Ansible run.