### PR TITLE
Add a way to delay activation of network interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 v0.1.1
 ------
 
-*Unreleased*
+*Released: 2015-05-12*
 
 - Add ``item.port_present`` parameter in bridge configuration. It can be used
   to enable or disable specific bridge interface depending on presence of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,16 @@ v0.1.1
   network interfaces which have been modified will be enabled/disabled on
   subsequent runs. [drybjed]
 
+- Add a way to delay activation of specific network interface.
+
+  A network interface can be prepared beforehand by ``debops.ifupdown`` role,
+  then additional configuration can be performed (for example an OpenVPN/tinc
+  VPN, GRE tunnel, etc.) and after that the other role can run the script
+  prepared by ``debops.ifupdown`` in a known location to start the interface.
+
+  This option is enabled by adding ``item.auto_ifup: False`` to interface
+  configuration. [drybjed]
+
 v0.1.0
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,5 +69,7 @@ ifupdown_interfaces: []
   #  delete: False/True			# remove this interface config file
   #  force: False/True			# force creation of this interface configuration
   #                                     # even if role thinks otherwise
-
+  #  auto_ifup: True/False              # don't start the interface automatically, instead
+  #                                     # generate a script that can be executed later
+  #                                     # to bring the interface up
 

--- a/templates/tmp/ifupdown-changed-interfaces.j2
+++ b/templates/tmp/ifupdown-changed-interfaces.j2
@@ -8,6 +8,7 @@
 {% endif %}
 {% set ifupdown_tpl_generated_interfaces = [] %}
 {% set ifupdown_tpl_enabled_interfaces = [] %}
+{% set ifupdown_tpl_start_interfaces = [] %}
 {% if ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed %}
 {% for result in ifupdown_register_interfaces_generator.results %}
 {% if result.changed %}
@@ -15,6 +16,9 @@
 {% endif %}
 {% if result.changed and result.item|d() and (result.item.inet is undefined or result.item.inet != 'manual') %}
 {% set _ = ifupdown_tpl_enabled_interfaces.append(result.item.iface) %}
+{% if result.item.auto_ifup is undefined or result.item.auto_ifup %}
+{% set _ = ifupdown_tpl_start_interfaces.append(result.item.iface) %}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -23,5 +27,6 @@
 interface_removed=( {{ (ifupdown_tpl_removed_interfaces | difference(ifupdown_tpl_generated_interfaces)) | sort | unique | join(" ") }} )
 interface_generated=( {{ (ifupdown_tpl_generated_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
 interface_enabled=( {{ (ifupdown_tpl_enabled_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
+interface_start=( {{ (ifupdown_tpl_start_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
 interface_list=( {{ ifupdown_tpl_interface_list | join(" ") }} )
 {% endif %}

--- a/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
+++ b/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
@@ -6,11 +6,17 @@
 # Part of the debops.ifupdown Ansible role
 # See https://github.com/debops/ansible-ifupdown/ for more details
 
+# Script filename to use in log messages
+script="$(basename $0)"
+
 # If this file is present, interfaces are configured for the first time
 interface_init_file="{{ ifupdown_reconfigure_init_file }}"
 
 # Get the name of the temporary file which holds the list of modified interfaces
 interface_file="${1}"
+
+# Path and name of the script which will allow to bring the interface up later
+ifup_delayed="/tmp/ifupdown-delayed"
 
 if [ -z "${interface_file}" ] ; then
   echo "Error: no file with list of interfaces specified" ; exit 1
@@ -28,6 +34,8 @@ containsElement () {
 # Re-initialization of interfaces, stop all/unknown ones
 stop_networking () {
 
+  logger -t ${script} Stopping networking service
+
   if [ -d /run/systemd/system ] ; then
     systemctl stop networking.service
   else
@@ -38,6 +46,8 @@ stop_networking () {
 
 # Check what init we are using and bring interface down correctly
 interface_down () {
+
+  logger -t ${script} Shutting down ${1} interface
 
   if [ -d /run/systemd/system ] ; then
 
@@ -64,10 +74,44 @@ interface_up () {
         ln -s /lib/systemd/system/ifup@.service /etc/systemd/system/multi-user.target.wants/ifup@${1}.service
     fi
 
-    systemctl start ifup@${1}.service
+    if $(containsElement "${1}" "${interface_start[@]}") ; then
+
+      logger -t ${script} Starting up ${1} interface
+
+      systemctl start ifup@${1}.service
+
+    else
+
+      logger -t ${script} Preparing script to activate ${1} later
+
+      ( umask 077 ; touch ${ifup_delayed}-${1} )
+      cat <<EOF >> ${ifup_delayed}-${1}
+#!/bin/sh
+systemctl start ifup@${1}.service
+rm -f ${ifup_delayed}-${1}
+EOF
+      chmod u+x ${ifup_delayed}-${1}
+    fi
 
   else
-    ifup ${1}
+
+    if $(containsElement "${1}" "${interface_start[@]}") ; then
+
+      logger -t ${script} Starting up ${1} interface
+      ifup ${1}
+
+    else
+
+      logger -t ${script} Preparing script to activate ${1} later
+
+      ( umask 077 ; touch ${ifup_delayed}-${1} )
+      cat <<EOF >> ${ifup_delayed}-${1}
+#!/bin/sh
+ifup ${1}
+rm -f ${ifup_delayed}-${1}
+EOF
+      chmod u+x ${ifup_delayed}-${1}
+    fi
   fi
 
 }


### PR DESCRIPTION
A network interface can be prepared beforehand by 'debops.ifupdown'
role, then additional configuration can be performed (for example an
OpenVPN/tinc VPN, GRE tunnel, etc.) and after that the other role can
run the script prepared by 'debops.ifupdown' in a known location to
start the interface.

This option is enabled by adding 'item.auto_ifup: False' to interface
configuration.