### PR TITLE
Various interface modifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,16 @@ v0.1.2
   interfaces are enabled. Additionally, send list of configured interfaces to
   the syslog for debugging purposes. [drybjed]
 
+- Add ``item.port_active`` parameter to bridge configuration.
+
+  If this parameter is set, specified ``item.port`` or ``item.port_present``
+  must be in a given active state (``True`` / ``False``) to configure the
+  bridge.
+
+  This helps mitigate an issue where bridge with DHCP configuration is
+  constantly running ``dhclient`` when its main interface is not connected to
+  the network. [drybjed]
+
 v0.1.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.1.2
+------
+
+*Unreleased*
+
+- Check first argument in the delayed ifup script, if it's ``false``, specified
+  interface won't be brought up at all. [drybjed]
+
 v0.1.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ v0.1.2
   interfaces. ``ifupdown`` and ``/etc/init.d/networking`` scripts work just
   fine without them present. [drybjed]
 
+- Split ``interface_enabled`` list into two to better track what types of
+  interfaces are enabled. Additionally, send list of configured interfaces to
+  the syslog for debugging purposes. [drybjed]
+
 v0.1.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,11 @@ v0.1.2
   constantly running ``dhclient`` when its main interface is not connected to
   the network. [drybjed]
 
+- Add a way to postpone interface configuration entirely using a separate
+  temporary script, with optional pre- and post- commands. This script will be
+  run at the end of the current play, or can be executed independently.
+  [drybjed]
+
 v0.1.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ v0.1.2
 - Check first argument in the delayed ifup script, if it's ``false``, specified
   interface won't be brought up at all. [drybjed]
 
+- Remove management if ``ifup@.service`` unit symlinks for configured
+  interfaces. ``ifupdown`` and ``/etc/init.d/networking`` scripts work just
+  fine without them present. [drybjed]
+
 v0.1.1
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 v0.1.2
 ------
 
-*Unreleased*
+*Released: 2015-05-24*
 
 - Check first argument in the delayed ifup script, if it's ``false``, specified
   interface won't be brought up at all. [drybjed]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,7 @@ ifupdown_interfaces: []
   #                                     # ansible_interfaces, adds 'bridge_ports <port>' line
   #					# (one ping, err, port only)
   #  port_present: ''                   # enable a bridge if given port is present in ansible_interfaces
+  #  port_active: True/False            # configure bridge only of port is connected / disconnected
   #  device: ''				# VLAN device to use, adds 'vlan_raw_device <device>' line
   #
   #  # Management of files in /etc/network/interfaces.d/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,19 @@ ifupdown_ignore_networkmanager: False
 # in practice. Specify a filename without '.yml' extension
 ifupdown_default_config: ""
 
+# Apply generated interface configuration immediately. If set to False, role
+# will generate a script in ``/tmp/`` directory which will apply configuration
+# at the end of the current Ansible play.
+ifupdown_apply_config: True
+
+# Shell commands in YAML text block format, which will be executed by the
+# config script before interface reconfiguration
+ifupdown_apply_config_pre_script: ''
+
+# Shell commands in YAML text block format, which will be executed by the
+# config script after interface reconfiguration
+ifupdown_apply_config_post_script: ''
+
 # List of network interfaces. If it's not defined, ifupdown role will
 # automatically select a default set based on variables like presence of
 # NetworkManager or value of ansible_virtualization_type

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Apply ifupdown configuration
+  shell: test ! -x /tmp/ifupdown-apply-config || /tmp/ifupdown-apply-config
+

--- a/tasks/generate_interfaces.yml
+++ b/tasks/generate_interfaces.yml
@@ -92,9 +92,21 @@
           (ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed)) and
          (ifupdown_reconfigure is defined and ifupdown_reconfigure))
 
+- name: Generate config script in a known location
+  template:
+    src: 'tmp/ifupdown-apply-config.j2'
+    dest: '/tmp/ifupdown-apply-config'
+    owner: 'root'
+    group: 'root'
+    mode: '0700'
+  notify: [ 'Apply ifupdown configuration' ]
+  when: (((ifupdown_register_interfaces_removator is defined and ifupdown_register_interfaces_removator.changed) or
+          (ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed)) and
+         ((ifupdown_reconfigure is defined and ifupdown_reconfigure) and (ifupdown_apply_config is defined and not ifupdown_apply_config | bool)))
+
 - name: Reconfigure network interfaces
   command: '{{ ansible_local.root.lib + "/ifupdown-reconfigure-interfaces " + ifupdown_register_tempdir.stdout + "/ifupdown-changed-interfaces" }}'
   when: (((ifupdown_register_interfaces_removator is defined and ifupdown_register_interfaces_removator.changed) or
           (ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed)) and
-         (ifupdown_reconfigure is defined and ifupdown_reconfigure))
+         ((ifupdown_reconfigure is defined and ifupdown_reconfigure) and (ifupdown_apply_config is defined and ifupdown_apply_config | bool)))
 

--- a/templates/etc/network/interfaces.d/bridge.j2
+++ b/templates/etc/network/interfaces.d/bridge.j2
@@ -2,7 +2,8 @@
 
 {% if item.type is defined and item.type == 'bridge' %}
 {% if (item.port_present is undefined or item.port_present in ansible_interfaces or (item.force is defined and item.force)) %}
-{% if (item.port is undefined) or (item.port is defined and item.port in ansible_interfaces) or (item.force is defined and item.force) %}
+{% if (item.port is undefined or item.port in ansible_interfaces or (item.force is defined and item.force)) %}
+{% if (item.port_active is undefined or (item.port_active is defined and ((item.port|d() and item.port_active | bool == hostvars[inventory_hostname]["ansible_" + item.port|d()].active | bool) or (item.port_present|d() and item.port_active | bool == hostvars[inventory_hostname]["ansible_" + item.port_present|d()].active | bool)))) %}
 # Configuration for {{ item.iface }} bridge
 {% if item.auto is undefined or item.auto %}
 allow-auto {{ item.iface }}
@@ -36,10 +37,13 @@ iface {{ item.iface }} inet static
 {% endfor %}
 {% endif %}
 {% else %}
-# Cannot find port {{ item.port }} for bridge {{ item.iface }}
+# Bridge {{ item.iface }} wants interface {{ item.port|d(item.port_present|d()) }} active: {{ item.port_active }}, found: {{ hostvars[inventory_hostname]["ansible_" + item.port|d(item.port_present|d())].active }}
 {% endif %}
 {% else %}
-# Interface {{ item.port_present }} not found
+# Interface {{ item.port }} not found
+{% endif %}
+{% else %}
+# Parent interface {{ item.port_present }} not found
 {% endif %}
 {% else %}
 # Wrong configuration for {{ item.iface }} bridge

--- a/templates/tmp/ifupdown-apply-config.j2
+++ b/templates/tmp/ifupdown-apply-config.j2
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+{% if ifupdown_apply_config_pre_script|d() and ifupdown_apply_config_pre_script %}
+{{ ifupdown_apply_config_pre_script }}
+{% endif %}
+
+# Reconfigure interfaces
+{{ ansible_local.root.lib + "/ifupdown-reconfigure-interfaces " + ifupdown_register_tempdir.stdout + "/ifupdown-changed-interfaces" }}
+
+{% if ifupdown_apply_config_post_script|d() and ifupdown_apply_config_post_script %}
+{{ ifupdown_apply_config_post_script }}
+{% endif %}
+
+# Remove thyself
+rm -f $(readlink -f ${0})
+

--- a/templates/tmp/ifupdown-changed-interfaces.j2
+++ b/templates/tmp/ifupdown-changed-interfaces.j2
@@ -19,6 +19,8 @@
 {% if result.item.auto_ifup is undefined or result.item.auto_ifup %}
 {% set _ = ifupdown_tpl_start_interfaces.append(result.item.iface) %}
 {% endif %}
+{% if result.changed and result.item|d() and (result.item.auto_ifup is undefined or result.item.auto_ifup) %}
+{% set _ = ifupdown_tpl_start_interfaces.append(result.item.iface) %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/tmp/ifupdown-changed-interfaces.j2
+++ b/templates/tmp/ifupdown-changed-interfaces.j2
@@ -7,17 +7,19 @@
 {% endfor %}
 {% endif %}
 {% set ifupdown_tpl_generated_interfaces = [] %}
-{% set ifupdown_tpl_enabled_interfaces = [] %}
+{% set ifupdown_tpl_auto_interfaces = [] %}
+{% set ifupdown_tpl_hotplug_interfaces = [] %}
 {% set ifupdown_tpl_start_interfaces = [] %}
 {% if ifupdown_register_interfaces_generator is defined and ifupdown_register_interfaces_generator.changed %}
 {% for result in ifupdown_register_interfaces_generator.results %}
 {% if result.changed %}
 {% set _ = ifupdown_tpl_generated_interfaces.append(result.item.iface) %}
 {% endif %}
-{% if result.changed and result.item|d() and (result.item.inet is undefined or result.item.inet != 'manual') %}
-{% set _ = ifupdown_tpl_enabled_interfaces.append(result.item.iface) %}
-{% if result.item.auto_ifup is undefined or result.item.auto_ifup %}
-{% set _ = ifupdown_tpl_start_interfaces.append(result.item.iface) %}
+{% if result.changed and result.item|d() and ((result.item.auto is undefined or result.item.auto | bool) and (result.item.inet is undefined or result.item.inet != 'manual')) %}
+{% set _ = ifupdown_tpl_auto_interfaces.append(result.item.iface) %}
+{% endif %}
+{% if result.changed and result.item|d() and ((result.item.allow is undefined or result.item.allow | bool) and (result.item.inet is undefined or result.item.inet != 'manual')) %}
+{% set _ = ifupdown_tpl_hotplug_interfaces.append(result.item.iface) %}
 {% endif %}
 {% if result.changed and result.item|d() and (result.item.auto_ifup is undefined or result.item.auto_ifup) %}
 {% set _ = ifupdown_tpl_start_interfaces.append(result.item.iface) %}
@@ -28,7 +30,8 @@
 {% if ifupdown_tpl_interface_list %}
 interface_removed=( {{ (ifupdown_tpl_removed_interfaces | difference(ifupdown_tpl_generated_interfaces)) | sort | unique | join(" ") }} )
 interface_generated=( {{ (ifupdown_tpl_generated_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
-interface_enabled=( {{ (ifupdown_tpl_enabled_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
+interface_auto=( {{ (ifupdown_tpl_auto_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
+interface_hotplug=( {{ (ifupdown_tpl_hotplug_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
 interface_start=( {{ (ifupdown_tpl_start_interfaces | difference(ifupdown_tpl_removed_interfaces)) | sort | unique | join(" ") }} )
 interface_list=( {{ ifupdown_tpl_interface_list | join(" ") }} )
 {% endif %}

--- a/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
+++ b/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
@@ -116,6 +116,8 @@ EOF
 if [ -r ${interface_file} ] ; then
   source ${interface_file}
 
+  logger -t ${script} Interface state: removed: ${interface_removed[@]}; generated: ${interface_generated[@]}; auto: ${interface_auto[@]}; hotplug: ${interface_hotplug[@]}; start: ${interface_start[@]}; list: ${interface_list[@]}
+
   if [ ${{ '{' }}#interface_list[@]} -ge 0 ]; then
 
     # Stop all interfaces on the first run

--- a/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
+++ b/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
@@ -87,7 +87,9 @@ interface_up () {
       ( umask 077 ; touch ${ifup_delayed}-${1} )
       cat <<EOF >> ${ifup_delayed}-${1}
 #!/bin/sh
-systemctl start ifup@${1}.service
+if [ -z "\${1}" -o "\${1}" != "false" ] ; then
+  systemctl start ifup@${1}.service
+fi
 rm -f ${ifup_delayed}-${1}
 EOF
       chmod u+x ${ifup_delayed}-${1}
@@ -107,7 +109,9 @@ EOF
       ( umask 077 ; touch ${ifup_delayed}-${1} )
       cat <<EOF >> ${ifup_delayed}-${1}
 #!/bin/sh
-ifup ${1}
+if [ -z "\${1}" -o "\${1}" != "false" ] ; then
+  ifup ${1}
+fi
 rm -f ${ifup_delayed}-${1}
 EOF
       chmod u+x ${ifup_delayed}-${1}

--- a/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
+++ b/templates/usr/local/lib/ifupdown-reconfigure-interfaces.j2
@@ -53,11 +53,6 @@ interface_down () {
 
     systemctl stop ifup@${1}.service
 
-    if $(containsElement "${1}" "${interface_removed[@]}") ; then
-      test -e /etc/systemd/system/multi-user.target.wants/ifup@${1}.service && \
-        rm -f /etc/systemd/system/multi-user.target.wants/ifup@${1}.service
-    fi
-
   else
     ifdown ${1}
   fi
@@ -68,11 +63,6 @@ interface_down () {
 interface_up () {
 
   if [ -d /run/systemd/system ] ; then
-
-    if $(containsElement "${1}" "${interface_enabled[@]}") ; then
-      test -e /etc/systemd/system/multi-user.target.wants/ifup@${1}.service || \
-        ln -s /lib/systemd/system/ifup@.service /etc/systemd/system/multi-user.target.wants/ifup@${1}.service
-    fi
 
     if $(containsElement "${1}" "${interface_start[@]}") ; then
 

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -18,6 +18,7 @@ ifupdown_default_interfaces:
   - iface: 'br0'
     type: 'bridge'
     port: '{{ ifupdown_external_interface }}'
+    port_active: True
 
   - iface: 'br0'
     auto: False
@@ -25,10 +26,12 @@ ifupdown_default_interfaces:
     type: 'bridge'
     inet6: 'auto'
     port_present: '{{ ifupdown_external_interface }}'
+    port_active: True
 
   - iface: 'br1'
     type: 'bridge'
     port: '{{ ifupdown_internal_interface }}'
+    port_active: True
 
   - iface: 'br1'
     auto: False
@@ -36,4 +39,5 @@ ifupdown_default_interfaces:
     type: 'bridge'
     inet6: 'auto'
     port_present: '{{ ifupdown_internal_interface }}'
+    port_active: True
 


### PR DESCRIPTION
- Check first argument in the delayed ifup script, if it's `false`, specified
  interface won't be brought up at all.

- Remove management if `ifup@.service` unit symlinks for configured
  interfaces. `ifupdown` and ``/etc/init.d/networking`` scripts work just
  fine without them present.

- Split `interface_enabled` list into two to better track what types of
  interfaces are enabled. Additionally, send list of configured interfaces to
  the syslog for debugging purposes.

- Add `item.port_active` parameter to bridge configuration.

  If this parameter is set, specified `item.port` or `item.port_present`
  must be in a given active state (`True` / `False`) to configure the
  bridge.

  This helps mitigate an issue where bridge with DHCP configuration is
  constantly running `dhclient` when its main interface is not connected to
  the network.

- Add a way to postpone interface configuration entirely using a separate
  temporary script, with optional pre- and post- commands. This script will be
  run at the end of the current play, or can be executed independently.