### PR TITLE
Add 'ifupdown_interface_weight_map' variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,33 @@ v0.2.3
 
 - Updated documentation and fixed spelling. [ypid]
 
+- Add ``ifupdown_interface_weight_map`` variable.
+
+  This variable defines default values of ``item.weight`` parameter for
+  different interface types. This is needed because order of interfaces managed
+  by ``ifupdown`` is significant and different interface types should be
+  specified in correct order (for example interface definitions should be
+  specified before bridges that use these interfaces).
+
+  If you specify the weight of each interface manually using ``item.weight``
+  parameter, your configuration shouldn't be affected.
+
+  This change will most likely generate new sets of interface configuration in
+  ``/etc/network/interfaces.d/`` on already configured hosts. To prevent
+  duplication of configuration, you can remove the configuration stored in
+  ``/etc/network/interfaces.config.d/`` before running the role.
+
+  Because from the ``ifupdown`` perspective configuration of each interface
+  changed, after new configuration is generated each interface will be brought
+  down and up again. You shouldn't lose the connection to remote host, but
+  local (or remote console) access might be handy.
+
+  Because bridges will be restarted, any external interfaces connected to them
+  will be dropped. That means that virtual machines and containers will lose
+  the network connection permanently. Restarting the afftected virtual machines
+  and containers should bring everything back to normal. [drybjed]
+
+
 v0.2.2
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,6 +122,24 @@ ifupdown_external_interface: 'eth0'
 ifupdown_internal_interface: 'eth1'
 
 
+# .. envvar:: ifupdown_interface_weight_map
+#
+# Configuration of network interfaces is read executed in alphabetical order.
+# Because of that, order of different interface types is significant. This
+# dictionary provides a mapping between various interface types and a "weight"
+# value which will be prepended to the interface filename to create correct order
+# of network interfaces.
+#
+# You can override the default weight by specifying ``item.weight`` key in
+# interface configuration.
+ifupdown_interface_weight_map:
+  'mapping':   '00'
+  'interface': '10'
+  'bond':      '20'
+  'vlan':      '40'
+  'bridge':    '60'
+
+
 # .. envvar:: ifupdown_default_bridge_options
 #
 # Default options added to each bridge if no custom options have been

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -138,8 +138,9 @@ List of interface parameters
   the port is not in a given state, then the configuration won't be generated.
 
 ``weight``
-  Numerical value added at the beginning of the interface configuration file,
-  by default ``00``. Can be used to influence the order of interfaces.
+  Numerical value added at the beginning of the interface configuration file.
+  If not specified, a value will be set from ``ifupdown_interface_weight_map``
+  variable depending on the type of the interface.
 
 ``filename``
   Name of the configuration file to generate. If not specified, an unique

--- a/tasks/generate_interfaces.yml
+++ b/tasks/generate_interfaces.yml
@@ -49,7 +49,7 @@
 
 - name: Delete interface configuration if requested
   file:
-    path: '{{ "/etc/network/interfaces.config.d/" + item.weight | default("00") + "_" + item.filename | default(item.alias | default(item.type | default("interface")) + "_" + item.iface) + (("_" + item.label) if (item.label is defined and item.label) else "") + ("_ipv4" if (item.inet is defined and item.inet) else "") + ("_ipv6" if (item.inet6 is defined and item.inet6) else "") }}'
+    path: '{{ "/etc/network/interfaces.config.d/" + (item.weight | d(ifupdown_interface_weight_map[item.type|d("interface")])) + "_" + item.filename | default(item.alias | default(item.type | default("interface")) + "_" + item.iface) + (("_" + item.label) if (item.label is defined and item.label) else "") + ("_ipv4" if (item.inet is defined and item.inet) else "") + ("_ipv6" if (item.inet6 is defined and item.inet6) else "") }}'
     state: 'absent'
   with_items: ifupdown_interfaces
   register: ifupdown_register_interfaces_removator
@@ -59,7 +59,7 @@
 - name: Generate interface configuration
   template:
     src: 'etc/network/interfaces.d/{{ item.type | default("interface") }}.j2'
-    dest: '{{ "/etc/network/interfaces.config.d/" + item.weight | default("00") + "_" + item.filename | default(item.alias | default(item.type | default("interface")) + "_" + item.iface) + (("_" + item.label) if (item.label is defined and item.label) else "") + ("_ipv4" if (item.inet is defined and item.inet) else "") + ("_ipv6" if (item.inet6 is defined and item.inet6) else "") }}'
+    dest: '{{ "/etc/network/interfaces.config.d/" + (item.weight | d(ifupdown_interface_weight_map[item.type|d("interface")])) + "_" + item.filename | default(item.alias | default(item.type | default("interface")) + "_" + item.iface) + (("_" + item.label) if (item.label is defined and item.label) else "") + ("_ipv4" if (item.inet is defined and item.inet) else "") + ("_ipv6" if (item.inet6 is defined and item.inet6) else "") }}'
     owner: 'root'
     group: 'root'
     mode: '0644'


### PR DESCRIPTION
This variable defines default values of 'item.weight' parameter for
different interface types. This is needed because order of interfaces
managed by 'ifupdown' is significant and different interface types
should be specified in correct order (for example interface definitions
should be specified before bridges that use these interfaces).

If you specify the weight of each interface manually using 'item.weight'
parameter, your configuration shouldn't be affected.

This change will most likely generate new sets of interface
configuration in '/etc/network/interfaces.d/' on already configured
hosts. To prevent duplication of configuration, you can remove the
configuration stored in '/etc/network/interfaces.config.d/' before
running the role.

Because from the 'ifupdown' perspective configuration of each interface
changed, after new configuration is generated each interface will be
brought down and up again. You shouldn't lose the connection to remote
host, but local (or remote console) access might be handy.

Because bridges will be restarted, any external interfaces connected to
them will be dropped. That means that virtual machines and containers
will lose the network connection permanently. Restarting the afftected
virtual machines and containers should bring everything back to normal.