### PR TITLE
Fix condition for ifenslave installation

### DIFF
--- a/templates/lookup/ifupdown__dynamic_packages.j2
+++ b/templates/lookup/ifupdown__dynamic_packages.j2
@@ -6,7 +6,7 @@
 {%         set _ = ifupdown__tpl_packages.append('bridge-utils') %}
 {%       elif params.type == 'vlan' %}
 {%         set _ = ifupdown__tpl_packages.append('vlan') %}
-{%       elif params.type == 'bond' %}
+{%       elif params.type == 'bonding' %}
 {%         if ansible_distribution_release == 'wheezy' %}
 {%           set _ = ifupdown__tpl_packages.append('ifenslave-2.6') %}
 {%         else %}


### PR DESCRIPTION
The type for bonded interfaces is 'bonding' and not 'bond' according to
the documentation and other parts of the code.